### PR TITLE
Added remove collaborator api

### DIFF
--- a/controllers/gigController.js
+++ b/controllers/gigController.js
@@ -186,3 +186,27 @@ export async function addCollaborator(req, res) {
     res.status(500).json({ error: 'An error occurred while adding the collaborator.' });
   }
 }
+
+export async function removeCollaborator(req, res) {
+  const { gig_id, collaborator_id } = req.params;
+
+  try {
+    const gig = await Gig.findByIdAndUpdate(
+      gig_id,
+      { $pull: { collaborators: collaborator_id } },
+      { new: true }
+    ).populate('collaborators', 'name email');
+
+    if (!gig) {
+      return res.status(404).json({ error: 'Gig not found' });
+    }
+
+    res.status(200).json({
+      message: 'Collaborator removed successfully',
+      gig,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'An error occurred while removing the collaborator.' });
+  }
+}

--- a/routes/gigRoutes.js
+++ b/routes/gigRoutes.js
@@ -16,6 +16,9 @@ router.post('/create_gig', gigController.createGig);
 // Route to add collaborator to a gig
 router.patch('/gigs/:gig_id/collaborators', gigController.addCollaborator);
 
+// Route to remove collaborator from a gig
+router.delete('/gigs/:gig_id/collaborators/:collaborator_id', gigController.removeCollaborator);
+
 // Route to update the status of a gig
 router.patch('/update_gig', gigController.updateGigStatus);
 


### PR DESCRIPTION
### Summary
This update adds functionality to remove a collaborator from a gig using the DELETE endpoint.

### Changes
- **Route:** Added `router.delete('/gigs/:gig_id/collaborators/:collaborator_id')`.
- **Controller:** Implemented the `removeCollaborator` method to:
  - Remove the specified collaborator from the `collaborators` field in the gig document.
  - Use the `$pull` operator to update the gig.
  - Return the updated gig with populated collaborator details (`name` and `email`).
  - Handle errors and send appropriate responses for missing gigs or server issues.

### Purpose
To enable the removal of a specific collaborator from a gig efficiently and handle edge cases like missing gig IDs or unexpected errors.