### PR TITLE
Add gig engagement status to interested gigs response

### DIFF
--- a/controllers/gigEngagementController.js
+++ b/controllers/gigEngagementController.js
@@ -108,7 +108,12 @@ export const getInterestedGigs = async (req, res) => {
       return res.status(404).json({ message: 'No interested gigs found' });
     }
 
+    // Extract gig IDs and engagement statuses
     const gigIds = engagements.map((engagement) => engagement.gig_id);
+    const engagementStatuses = engagements.reduce((acc, engagement) => {
+      acc[engagement.gig_id.toString()] = engagement.status;  // Map gig_id to its engagement status
+      return acc;
+    }, {});
 
     const gigs = await Gig.find({ _id: { $in: gigIds } }).populate({
       path: 'manager_id',
@@ -124,7 +129,8 @@ export const getInterestedGigs = async (req, res) => {
         title: gig.title,
         ustar_category: gig.ustar_category,
         status: gig.status,
-        manager_details: gig.manager_id 
+        manager_details: gig.manager_id,
+        gig_engagement_status: engagementStatuses[gig._id.toString()] // Add engagement status
       }))
     });
   } catch (error) {
@@ -132,3 +138,4 @@ export const getInterestedGigs = async (req, res) => {
     res.status(500).json({ error: 'Internal server error' });
   }
 };
+

--- a/controllers/gigEngagementController.js
+++ b/controllers/gigEngagementController.js
@@ -94,30 +94,6 @@ console.dir(gig_id)
   }
 }
 
-export async function getInterestedUser(req, res) {
-  const { gig_id } = req.params;
-  const user_id = req.headers['user_id'];
-
-  try {
-    const engagement = await GigEngagement.findOne({ gig_id, user_id });
-
-    if (!engagement) {
-      return res.status(404).json({ message: 'User not found who showed interest in this gig.' });
-    }
-
-    res.json({
-      message: 'User found who showed interest in the gig',
-      gig_id,
-      user_id,
-      status: engagement.status,
-    });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'An error occurred while fetching interested user.' });
-  }
-}
-
-
 export const getInterestedGigs = async (req, res) => {
   const user_id = req.headers['user_id'];
 

--- a/controllers/gigEngagementController.js
+++ b/controllers/gigEngagementController.js
@@ -94,6 +94,29 @@ console.dir(gig_id)
   }
 }
 
+export async function getInterestedUser(req, res) {
+  const { gig_id } = req.params;
+  const user_id = req.headers['user_id'];
+
+  try {
+    const engagement = await GigEngagement.findOne({ gig_id, user_id });
+
+    if (!engagement) {
+      return res.status(404).json({ message: 'User not found who showed interest in this gig.' });
+    }
+
+    res.json({
+      message: 'User found who showed interest in the gig',
+      gig_id,
+      user_id,
+      status: engagement.status,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'An error occurred while fetching interested user.' });
+  }
+}
+
 
 export const getInterestedGigs = async (req, res) => {
   const user_id = req.headers['user_id'];

--- a/routes/gigRoutes.js
+++ b/routes/gigRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import * as gigController from '../controllers/gigController.js';
-import { expressInterestInGig, updateGigEngagementStatus, getInterestedUsers, getInterestedGigs } from '../controllers/gigEngagementController.js';
+import { expressInterestInGig, updateGigEngagementStatus, getInterestedUsers, getInterestedGigs, getInterestedUser } from '../controllers/gigEngagementController.js';
 
 const router = express.Router();
 
@@ -33,6 +33,9 @@ router.patch('/update_gig_engagement', updateGigEngagementStatus);
 
 // Endpoint to fetch interested users for a gig
 router.get('/gig/:gig_id/interested', getInterestedUsers);
+
+// Endpoint to fetch interested user for a gig with user_id
+router.get('/gig/:gig_id/interested_user', getInterestedUser);
 
 // Endpoint to fetch interested gigs by user
 router.get('/intrested_gigs', getInterestedGigs);

--- a/routes/gigRoutes.js
+++ b/routes/gigRoutes.js
@@ -1,6 +1,11 @@
 import express from 'express';
 import * as gigController from '../controllers/gigController.js';
-import { expressInterestInGig, updateGigEngagementStatus, getInterestedUsers, getInterestedGigs, getInterestedUser } from '../controllers/gigEngagementController.js';
+import { 
+    expressInterestInGig, 
+    updateGigEngagementStatus, 
+    getInterestedUsers, 
+    getInterestedGigs 
+} from '../controllers/gigEngagementController.js';
 
 const router = express.Router();
 
@@ -33,9 +38,6 @@ router.patch('/update_gig_engagement', updateGigEngagementStatus);
 
 // Endpoint to fetch interested users for a gig
 router.get('/gig/:gig_id/interested', getInterestedUsers);
-
-// Endpoint to fetch interested user for a gig with user_id
-router.get('/gig/:gig_id/interested_user', getInterestedUser);
 
 // Endpoint to fetch interested gigs by user
 router.get('/intrested_gigs', getInterestedGigs);


### PR DESCRIPTION
**Overview:**  
This PR modifies the `getInterestedGigs` API to include the user's engagement status for each gig in the response. Previously, the API returned details about the gigs but did not include the specific engagement status (e.g., "interested", "in-progress", "completed", "cancelled") of the user for each gig. This update ensures that the engagement status is now returned alongside other gig details.

**Changes:**
- Added a `gig_engagement_status` field to the gig details in the response.
- The `gig_engagement_status` is derived from the `GigEngagement` collection based on the user's involvement with the respective gig.
- Refactored the logic to map each gig's `_id` to its corresponding engagement status for easier lookup.

**Impact:**
- The API now returns a more comprehensive set of data for users, including their engagement status for each gig.
- The added field improves the user experience by providing complete information on their participation in gigs.

**Example Response:**
```json
{
  "message": "Interested gigs fetched successfully",
  "gigs": [
    {
      "_id": "678e1fdba6f1acaf9ac366d1",
      "topic": "Assassin's Creed",
      "description": "An anthology franchise of first-person shooter games, all of which have been published by Ubisoft. The first game, Far Cry, was developed by Crytek to premiere their CryEngine software, and released in March 2004.",
      "title": "Task updated pinnem",
      "ustar_category": "RisingStar",
      "status": "approved",
      "manager_details": {
        "_id": "675712e7450aead0d3a404f7",
        "name": "John Manager",
        "email": "john.manager@example.com",
        "profile_picture_url": "https://example.com/profile.jpg"
      },
      "gig_engagement_status": "interested"
    }
  ]
}

